### PR TITLE
add firebase auth

### DIFF
--- a/front/app/firebase/firebase.js
+++ b/front/app/firebase/firebase.js
@@ -1,0 +1,19 @@
+// firebaseをimportしています
+import firebase from "firebase/app";
+
+const firebaseConfig = {
+	// 先程Firebaseにアプリを追加するところでコピーしたコードを追加
+	apiKey: "AIzaSyBkc753CjSAaO0-niXn5jMSOoNZcP5T9pA",
+	authDomain: "tech-camp-vol13.firebaseapp.com",
+	projectId: "tech-camp-vol13",
+	storageBucket: "tech-camp-vol13.appspot.com",
+	messagingSenderId: "299848172445",
+	appId: "1:299848172445:web:511dfea008d575beb32574",
+	measurementId: "G-444EWVVJDB"
+};
+// Firebaseのインスタンスが存在しない場合にのみ、インスタンスを作成します
+if (!firebase.apps.length) {
+	firebase.initializeApp(firebaseConfig);
+}
+
+export default firebase;


### PR DESCRIPTION
Parsing error: Cannot find module 'next/babel'
Require stack:
- /home/haruto8692/hack-camp_vol13_2024/front/app/node_modules/next/dist/compiled/babel/bundle.js
- /home/haruto8692/hack-camp_vol13_2024/front/app/node_modules/next/dist/compiled/babel/eslint-parser.js
- /home/haruto8692/hack-camp_vol13_2024/front/app/node_modules/eslint-config-next/parser.js
- /home/haruto8692/hack-camp_vol13_2024/front/app/node_modules/@eslint/eslintrc/dist/eslintrc.cjs

Make sure that all the Babel plugins and presets you are using
are defined as dependencies or devDependencies in your package.json
file. It's possible that the missing plugin is loaded by a preset
you are using that forgot to add the plugin to its dependencies: you
can workaround this problem by explicitly adding the missing package
to your top-level package.json.


node_modules消してほしいとエラーが出るが, Firebaseのディレクトリ場所が悪いのかエラーが出続ける問題！！